### PR TITLE
Stop exposing sensitive env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Example environment variables for SmoothSwap
+# Sensitive keys should NOT use the VITE_ prefix so they remain server-side only.
+COINBASE_API_KEY=
+COINBASE_API_SECRET=
+
+# Public Supabase settings (these are safe to expose)
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=

--- a/src/config/coinbase.ts
+++ b/src/config/coinbase.ts
@@ -4,13 +4,8 @@ import { coinbaseWallet } from 'wagmi/connectors';
 import { http } from 'viem';
 import { createPublicClient, parseUnits, encodeFunctionData } from 'viem';
 
-// Validate environment variables
-const projectId = import.meta.env.VITE_COINBASE_PROJECT_ID;
-const apiKey = import.meta.env.VITE_COINBASE_API_KEY;
-
-if (!projectId || !apiKey) {
-  console.warn('Coinbase credentials not found. Some features may not work properly.');
-}
+// Coinbase credentials are now handled server-side and should not be exposed to the client.
+// Remove any VITE_ prefixed variables to prevent leaking sensitive values in the browser.
 
 // Contract addresses for session key permissions
 const AERODROME_ROUTER = '0xcF77a3Ba9A5CA399B7c97c74d54e5b1Beb874E43';
@@ -131,7 +126,6 @@ export const coinbaseConfig = createConfig({
       preference: 'smartWalletOnly',
       enableHostedBackups: false,
       version: '4',
-      ...(projectId && { projectId }),
     }),
   ],
   transports: {


### PR DESCRIPTION
## Summary
- prevent leaking coinbase credentials by removing VITE_ env usage in client config
- add example env file highlighting private vs public variables

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a15aa8e288832594d8d4ea416a48b8